### PR TITLE
Update Cycle.js counter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Allows for flyd streams to be embedded directly into JSX, and to update content 
 
 # Counter Example
 
-You can compare this example to [Counter example of Cycle.js](https://github.com/cyclejs/cycle-examples/blob/master/counter/src/main.js), [Counter example of Yolk](https://github.com/yolkjs/yolk#example), and [Counter example of React Reactive Class](https://github.com/jas-chen/react-reactive-class#counter-example).
+You can compare this example to [Counter example of Cycle.js](https://github.com/cyclejs/cyclejs/blob/master/examples/basic/counter/src/main.js), [Counter example of Yolk](https://github.com/yolkjs/yolk#example), and [Counter example of React Reactive Class](https://github.com/jas-chen/react-reactive-class#counter-example).
 
 ```javascript
 /** @jsx h */


### PR DESCRIPTION
The previous one 404ed due to cycle.js deprecating the examples repo.